### PR TITLE
Precompilation doesn't seem to like __init__.

### DIFF
--- a/src/AGFFileReader.jl
+++ b/src/AGFFileReader.jl
@@ -18,7 +18,7 @@ using DelimitedFiles: readdlm # used in agffile_to_catalog
 DATA_DIR = ""
 SCRATCH_NAME = "GlassData"
 
-function __init__()
+function initialize_glass_catalogs()
     scratch_dir = @get_scratch!(SCRATCH_NAME)
 
     glass_defs = joinpath(scratch_dir, "jl/AGFGlassCat.jl")


### PR DESCRIPTION
Removed __init__ and changed to initialize_glass_catalog which user must explicitly call. Won't get glass name completion in VSCode this way but should still work at the REPL.